### PR TITLE
Fix token size

### DIFF
--- a/token.go
+++ b/token.go
@@ -29,7 +29,7 @@ func resourceToken() *schema.Resource {
 
 func resourceTokenSet(d *schema.ResourceData, meta interface{}) error {
 	url := meta.(string)
-	size := d.Get("key")
+	size := d.Get("size")
 
 	if size != nil {
 		url += fmt.Sprintf("?size=%d", size.(int))


### PR DESCRIPTION
Fixing token size never worked and always defaulted to 3.